### PR TITLE
Avoiding observers override

### DIFF
--- a/lib/suscribir/engine.rb
+++ b/lib/suscribir/engine.rb
@@ -2,6 +2,9 @@ module Suscribir
   class Engine < Rails::Engine
     isolate_namespace Suscribir
 
-    config.active_record.observers = 'Suscribir::SuscripcionMediator'
+    # Para que la applicación arranque los observers hay que registralos evitando sobreescribir los que hayan sido
+    # asignados anteriormente por otras partes (por ejemplo, por otros engines)
+    config.active_record.observers = [config.active_record.observers].flatten.compact
+    config.active_record.observers << 'Suscribir::SuscripcionMediator'
   end
 end


### PR DESCRIPTION
I realized that assigning observers with `config.active_record.observers =` overrides the previous assigned observers.
The same happens when the main application assigns its observers using the `=` operator instead of the `<<` operator.
