### PR TITLE
Url desuscribir, the nasty way... that works

### DIFF
--- a/app/decorators/suscribir/suscripcion_decorator.rb
+++ b/app/decorators/suscribir/suscripcion_decorator.rb
@@ -5,9 +5,5 @@ module Suscribir
     def url_desuscribir
       h.engine_suscribir.pedir_confirmacion_baja_url(id, token)
     end
-
-    def enlace_desuscripcion_url(texto_url)
-      h.link_to(texto_url, url_desuscribir)
-    end
   end
 end

--- a/app/decorators/suscribir/suscripcion_decorator.rb
+++ b/app/decorators/suscribir/suscripcion_decorator.rb
@@ -3,7 +3,10 @@ module Suscribir
     delegate_all
 
     def url_desuscribir
-      h.engine_suscribir.pedir_confirmacion_baja_url(id, token)
+      "#{ HTTP_DOMINIOS[dominio_de_alta.to_sym] }/baja/#{ id }/#{ token }"
+      # SI QUIERES INTENTAR HACERLO BIEN CON
+      # h.engine_suscribir.pedir_confirmacion_baja_url(id, token, host: mi_dominio)
+      # ASEGURATE DE QUE TE FUNCIONE DESDE EL CRON
     end
   end
 end

--- a/app/modules/suscribir/suscribible.rb
+++ b/app/modules/suscribir/suscribible.rb
@@ -39,18 +39,6 @@ module Suscribir::Suscribible
     end
   end
 
-  def dame_datos_para_sendgrid(opciones = {})
-    datos = { emails: [], nombre: [], enlace_editar_perfil_url: [], enlace_baja: [] }
-    suscripciones_a_notificar(opciones).each do |suscripcion|
-      datos[:emails] << suscripcion.email
-      datos[:nombre] << suscripcion.nombre_apellidos
-      usuario = suscripcion.suscriptor.try(:decorado)
-      datos[:enlace_editar_perfil_url] << usuario.try(:enlace_editar_perfil_url)
-      datos[:enlace_baja] << suscripcion.decorate.enlace_desuscripcion_url('Desuscribirme de esta alerta')
-    end
-    datos
-  end
-
   def nombre_suscripcion
     try(:nombre) || try(:titulo)
   end


### PR DESCRIPTION
By what @d2bit and me have seen, engines + absolute routes + cron tasks are a fatal combination... and the only way to make them work is leaving apart Rails helpers and doing a simple string concatenation