### PR TITLE
Added suscribible.cookie_key

### DIFF
--- a/app/modules/suscribir/suscribible.rb
+++ b/app/modules/suscribir/suscribible.rb
@@ -38,6 +38,10 @@ module Suscribir::Suscribible
     try(:nombre) || try(:titulo)
   end
 
+  def cookie_key
+    "no_mostrar-#{ id_y_clase }"
+  end
+
   def id_y_clase
     "#{ id }-#{ self.class }"
   end


### PR DESCRIPTION
On captadores, we save cookies to stop messing users that have already seen them... and now the cookie's key should be provided by the suscribible